### PR TITLE
Use NoOpPasswordEncoder for encoding in-memory password.

### DIFF
--- a/src/main/kotlin/com/example/mediasamplekotlin/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/example/mediasamplekotlin/security/SecurityConfig.kt
@@ -36,8 +36,8 @@ class SecurityConfig : WebSecurityConfigurerAdapter() {
     fun configureGlobal(auth: AuthenticationManagerBuilder) {
         auth
                 .inMemoryAuthentication()
-                .withUser("user").password("user").roles("USER")
+                .withUser("user").password("{noop}user").roles("USER")
                 .and()
-                .withUser("admin").password("admin").roles("ADMIN")
+                .withUser("admin").password("{noop}admin").roles("ADMIN")
     }
 }


### PR DESCRIPTION
Use password encoder NoOpPasswordEncoder for encoding in-memory password.
But this is deprecated, so it's only for testing.